### PR TITLE
changed closeHtml from string to node - proptypes

### DIFF
--- a/src/Popup.react.js
+++ b/src/Popup.react.js
@@ -40,7 +40,7 @@ class Component extends React.Component {
         className: PropTypes.string,
         btnClass: PropTypes.string,
         closeBtn: PropTypes.bool,
-        closeHtml: PropTypes.string,
+        closeHtml: PropTypes.node,
         defaultOk: PropTypes.string,
         defaultOkKey: PropTypes.string,
         defaultCancel: PropTypes.string,


### PR DESCRIPTION
We already use a component (fontawesome component) to in place of closeHtml and it works out fine on our company project. The only reason this change is proposed is because of warnings on the console.