### PR TITLE
emit id on close

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -38,7 +38,7 @@ export default class PopupStore extends EventEmitter {
         const id = this.active;
         this.active = null;
 
-        this.emit(Constants.CLOSE);
+        this.emit(Constants.CLOSE, id);
         this.dispatch();
 
         this.value = null;


### PR DESCRIPTION
This is useful because `SHOW` emits an `id`, and so should `CLOSE` -- that way it's possible to know all open and closed popups. e.g.,

```jsx
constructor(props) {
    super(props);
    this.state = {
      openPopups: [],
    };
    Popup.addShowListener((pid) => {
      if (!this.state.openPopups.includes(pid)) { // this is because SHOW is also emitted when a popup is opened from the queue. 
        this.setState(({ openPopups }) => ({
          openPopups: [...openPopups, pid],
        }));
      }
    });
    Popup.addCloseListener((pid) => {
      this.setState(({ openPopups }) => ({
        openPopups: openPopups.filter(id => id !== pid),
      }));
    });
  }
```